### PR TITLE
Add packer template

### DIFF
--- a/packer/sugoi-service-base.json
+++ b/packer/sugoi-service-base.json
@@ -1,7 +1,7 @@
 {
   "variables": {
-    "aws_access_key": "",
-    "aws_secret_key": ""
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}"
   },
   "builders": [{
     "type": "amazon-ebs",

--- a/packer/sugoi-service-base.json
+++ b/packer/sugoi-service-base.json
@@ -8,9 +8,9 @@
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "ap-northeast-1",
-    "source_ami": "ami-3d50120d",
+    "source_ami": "ami-13614b12",
     "instance_type": "t2.micro",
-    "ssh_username": "ubuntu",
-    "ami_name": "packer-example {{timestamp}}"
+    "ssh_username": "root",
+    "ami_name": "packer-centos-example-{{timestamp}}"
   }]
 }

--- a/packer/sugoi-service-base.json
+++ b/packer/sugoi-service-base.json
@@ -1,0 +1,16 @@
+{
+  "variables": {
+    "aws_access_key": "",
+    "aws_secret_key": ""
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "region": "us-east-1",
+    "source_ami": "ami-3d50120d",
+    "instance_type": "t2.micro",
+    "ssh_username": "ubuntu",
+    "ami_name": "packer-example {{timestamp}}"
+  }]
+}

--- a/packer/sugoi-service-base.json
+++ b/packer/sugoi-service-base.json
@@ -17,7 +17,8 @@
     "type": "shell",
     "inline": [
       "sleep 30",
-      "sudo yum -y update"
+      "sudo yum -y update",
+      "sudo rm -f /root/.ssh/authorized_keys"
     ]
   }]
 }

--- a/packer/sugoi-service-base.json
+++ b/packer/sugoi-service-base.json
@@ -7,7 +7,7 @@
     "type": "amazon-ebs",
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
-    "region": "us-east-1",
+    "region": "ap-northeast-1",
     "source_ami": "ami-3d50120d",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",

--- a/packer/sugoi-service-base.json
+++ b/packer/sugoi-service-base.json
@@ -12,5 +12,12 @@
     "instance_type": "t2.micro",
     "ssh_username": "root",
     "ami_name": "packer-centos-example-{{timestamp}}"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "inline": [
+      "sleep 30",
+      "sudo yum -y update"
+    ]
   }]
 }


### PR DESCRIPTION
packerで`yum update`済みのAMIを作成します。
- 元のAMIはcentos公式のHVM版
- これはそのままつかうと6.5なので6.6にupdateさせます
  - セキュリティfixの意味合いもある
- 今後はこのpackerで生成されたAMIから新規にサーバを立ち上げます

試し方
- packerをインストールする

```
$ brew tap homebrew/binary
$ brew install packer
```
- awsのアクセスキーの設定をする
  - packer/sugoi-service-base.json に書いてあるのでdirenvなどで設定する
- 作成

```
$ packer build packer/sugoi-service-base.json
```
